### PR TITLE
chore: align Node engines with Homebridge (^22 || ^24)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,21 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-      
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, DEV ]
 
 permissions:
   contents: read
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v7

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ node_modules
 
 # Local dev sync script (machine-specific Docker paths)
 scripts/sync-to-homebridge.sh
+
+# Local Homebridge dev runtime
+test/.homebridge/
+test/accessories/
+test/cachedAccessories
+test/persist/
+test/config.live.json

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ ret=PARAM NG,msg=404 Not Found
 
 Some models require requests via `https` containing a registered client token.
 
+**TLS / OpenSSL 3:** No configuration is required. On Node.js 18+ (linked against OpenSSL 3.x), the plugin automatically selects a legacy TLS agent for HTTPS connections to Daikin controllers (legacy renegotiation support). At startup, Homebridge logs a line such as `TLS: HTTPS apiroute — using legacy TLS agent` when this applies. There is no `OpenSSL3` setting in the plugin config.
+
 It is necessary to register a client token with each device.
 The same token may be registered with multiple devices.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
 
-![node](https://img.shields.io/node/v/homebridge-daikin-tempsensor-nocloud)
+[![node](https://img.shields.io/badge/node-22%20%7C%2024-brightgreen)](https://github.com/cbrandlehner/homebridge-daikin-tempsensor-nocloud/blob/master/package.json)
 [![npm](https://img.shields.io/npm/dt/homebridge-daikin-tempsensor-nocloud.svg)](https://www.npmjs.com/package/homebridge-daikin-tempsensor-nocloud)
 [![npm](https://img.shields.io/npm/l/homebridge-daikin-tempsensor-nocloud.svg)](https://github.com/cbrandlehner/homebridge-daikin-tempsensor-nocloud/blob/master/LICENSE)
 [![npm version](https://badge.fury.io/js/homebridge-daikin-tempsensor-nocloud.svg)](https://badge.fury.io/js/homebridge-daikin-tempsensor-nocloud)
@@ -71,7 +71,7 @@ ret=PARAM NG,msg=404 Not Found
 
 Some models require requests via `https` containing a registered client token.
 
-**TLS / OpenSSL 3:** No configuration is required. On Node.js 18+ (linked against OpenSSL 3.x), the plugin automatically selects a legacy TLS agent for HTTPS connections to Daikin controllers (legacy renegotiation support). At startup, Homebridge logs a line such as `TLS: HTTPS apiroute — using legacy TLS agent` when this applies. There is no `OpenSSL3` setting in the plugin config.
+**TLS / OpenSSL 3:** No configuration is required. On Node.js 22+ (linked against OpenSSL 3.x), the plugin automatically selects a legacy TLS agent for HTTPS connections to Daikin controllers (legacy renegotiation support). At startup, Homebridge logs a line such as `TLS: HTTPS apiroute — using legacy TLS agent` when this applies. There is no `OpenSSL3` setting in the plugin config.
 
 It is necessary to register a client token with each device.
 The same token may be registered with multiple devices.

--- a/config.schema.json
+++ b/config.schema.json
@@ -63,12 +63,6 @@
         "default": "Default",
         "required": true
       },
-      "OpenSSL3": {
-        "title": "OpenSSL3 support",
-        "description": "Use new OpenSSL3 SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION option",
-        "type": "boolean",
-        "default": false
-      },
       "response": {
         "title": "Response",
         "description": "Timeout in milliseconds for the device to start responding.  Default: 2000 (2 seconds).",

--- a/dev/probe-device.sh
+++ b/dev/probe-device.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IP="${1:-192.168.71.136}"
+BASE="http://${IP}"
+
+echo "=== get_model_info ==="
+curl -s "${BASE}/aircon/get_model_info"
+echo ""
+echo ""
+echo "=== get_sensor_info ==="
+curl -s "${BASE}/aircon/get_sensor_info"
+echo ""
+echo ""
+echo "=== basic_info ==="
+curl -s "${BASE}/common/basic_info"
+echo ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-daikin-tempsensor-nocloud",
-  "version": "1.4.6",
+  "version": "1.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-daikin-tempsensor-nocloud",
-      "version": "1.4.6",
+      "version": "1.4.8",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-daikin-tempsensor-nocloud",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Provides temperature sensor for HomeKit as plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "MIT",
   "keywords": [
@@ -44,7 +44,10 @@
   "scripts": {
     "lint:json": "eslint .",
     "test": "node --test",
-    "pretest": "npm run lint:json"
+    "pretest": "npm run lint:json",
+    "dev": "npx homebridge -P . -U ./test -D",
+    "dev:live": "bash -c 'cp test/config.live.json test/config.json && npx homebridge -P . -U ./test -D'",
+    "probe:device": "bash dev/probe-device.sh"
   },
   "devDependencies": {
     "@eslint/json": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "engines": {
     "homebridge": "^1.10.0 || ^2.0.0-beta.0",
-    "node": "^20.19.0 || ^22.12.0 || ^24.0.0"
+    "node": "^22 || ^24"
   },
   "author": "Christian Brandlehner",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-daikin-tempsensor-nocloud",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Provides temperature sensor for HomeKit as plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "MIT",
   "keywords": [

--- a/src/host-resolve.js
+++ b/src/host-resolve.js
@@ -1,0 +1,90 @@
+/* eslint quotes: ["error", "single", { "avoidEscape": true }] */
+
+const dns = require('node:dns');
+const net = require('node:net');
+
+const DNS_CACHE_TTL_MS = 60_000;
+const dnsCache = new Map();
+
+/**
+ * @param {string} host Hostname or IP address.
+ * @returns {boolean}
+ */
+function isIpAddress(host) {
+  return net.isIP(host) !== 0;
+}
+
+/**
+ * @param {string} hostname Configured controller hostname.
+ * @returns {string|undefined}
+ */
+function getCachedDnsAddress(hostname) {
+  const cached = dnsCache.get(hostname);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.address;
+  }
+
+  return undefined;
+}
+
+/**
+ * @param {string} hostname Configured controller hostname.
+ * @param {string} address Resolved IPv4 address.
+ */
+function setCachedDnsAddress(hostname, address) {
+  dnsCache.set(hostname, {address, expiresAt: Date.now() + DNS_CACHE_TTL_MS});
+}
+
+/** Clear the in-memory DNS cache (used by tests). */
+function clearDnsCache() {
+  dnsCache.clear();
+}
+
+/**
+ * Resolve a configured controller host to IPv4. IP literals pass through unchanged.
+ *
+ * @param {string} hostname Hostname or IP from apiroute.
+ * @returns {Promise<string>}
+ */
+async function resolveControllerHost(hostname) {
+  if (isIpAddress(hostname)) {
+    return hostname;
+  }
+
+  const cached = getCachedDnsAddress(hostname);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const {address} = await dns.promises.lookup(hostname, {family: 4});
+    setCachedDnsAddress(hostname, address);
+    return address;
+  } catch {
+    return hostname;
+  }
+}
+
+/**
+ * Swap the URL hostname for a resolved IP while preserving port, path, and query.
+ *
+ * @param {string} url Request URL.
+ * @param {string} resolvedIP Resolved IPv4 address.
+ * @returns {string}
+ */
+function replaceHostInUrl(url, resolvedIP) {
+  try {
+    const parsed = new URL(url);
+    parsed.hostname = resolvedIP;
+    return parsed.href;
+  } catch {
+    return url;
+  }
+}
+
+module.exports = {
+  isIpAddress,
+  resolveControllerHost,
+  replaceHostInUrl,
+  clearDnsCache,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,44 @@ function isOpenSSL3() {
   return (process.versions.openssl || '').startsWith('3.');
 }
 
+/**
+ * @param {import('superagent').SuperAgentRequest} request
+ * @returns {import('superagent').SuperAgentRequest}
+ */
+function applyHttpsTls(request) {
+  if (isOpenSSL3()) {
+    return request.agent(getLegacyAgent());
+  }
+
+  if (typeof request.disableTLSCerts === 'function') {
+    return request.disableTLSCerts();
+  }
+
+  return request.agent(getDefaultAgent());
+}
+
+/**
+ * @param {import('homebridge').Logger} log
+ * @param {string} [apiroute]
+ */
+function logHttpsTlsPath(log, apiroute) {
+  if (!apiroute || !apiroute.startsWith('https://')) {
+    log.debug('TLS: apiroute uses HTTP — plain HTTP agent, no TLS');
+    return;
+  }
+
+  const openssl = process.versions.openssl || 'unknown';
+  if (isOpenSSL3()) {
+    log.info(
+      'TLS: HTTPS apiroute — using legacy TLS agent (Node OpenSSL %s; legacy renegotiation enabled automatically)',
+      openssl,
+    );
+    return;
+  }
+
+  log.info('TLS: HTTPS apiroute — using standard HTTPS agent (Node OpenSSL %s)', openssl);
+}
+
 let LEGACY_AGENT = null;
 let DEFAULT_AGENT = null;
 let DEFAULT_HTTP_AGENT = null;
@@ -85,7 +123,6 @@ function getDefaultHttpAgent() {
  * @param {number} [config.deadline] Superagent deadline timeout in milliseconds.
  * @param {number} [config.retries] Number of request retries on failure.
  * @param {'Default' | 'Skyfi'} [config.system] API path prefix for the controller type.
- * @param {boolean} [config.OpenSSL3] Force legacy TLS agent even when OpenSSL is not 3.x.
  * @param {string} [config.uuid] Optional `X-Daikin-uuid` header value.
  * @constructor
  */
@@ -166,11 +203,6 @@ function Daikin(log, config) {
     this.system = config.system;
   }
 
-  if (config.OpenSSL3 === undefined || config.OpenSSL3 === false)
-    this.OpenSSL3 = false;
-  else
-    this.OpenSSL3 = true;
-
   if (config.uuid === undefined)
     this.uuid = '';
   else
@@ -223,6 +255,7 @@ function Daikin(log, config) {
   this.log.info('accessory name: ' + this.name);
   this.log.info('accessory ip: ' + this.apiIP);
   this.log.debug('system: ' + this.system);
+  logHttpsTlsPath(this.log, config.apiroute);
   this.log.debug('Debug mode is enabled');
 
   this.temperatureService = new Service.TemperatureSensor(this.name);
@@ -332,13 +365,7 @@ Daikin.prototype = {
       }
 
       if (urlProtocol === 'https:') {
-        if (isOpenSSL3()) {
-          request = request.agent(getLegacyAgent());
-        } else if (typeof request.disableTLSCerts === 'function') {
-          request = request.disableTLSCerts();
-        } else {
-          request = request.agent(getDefaultAgent());
-        }
+        request = applyHttpsTls(request);
       } else {
         request = request.agent(getDefaultHttpAgent());
       }

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ const packageFile = require('../package.json');
 const Cache = require('./cache.js');
 const Queue = require('./queue.js');
 const parseResponse = require('./parse-response.js');
+const {resolveControllerHost, replaceHostInUrl} = require('./host-resolve.js');
 // const Throttle = require('superagent-throttle'); // optional, kept for parity if needed
 
 // --- BEGIN: OpenSSL / Agent helpers (added) ---
@@ -259,8 +260,15 @@ Daikin.prototype = {
 
       this._doSendGetRequest(path, (error, response) => {
         if (error) {
-          this.log.error('ERROR: Queued request to %s returned error %s', path, error);
-          callback(error);
+          if (error.code === 'ECONNRESET') {
+            this.log.debug('_queueGetRequest: requeueing request after econnreset');
+            options.skipQueue = true;
+            this._queueGetRequest(path, callback, options);
+          } else {
+            this.log.error('ERROR: Queued request to %s returned error %s', path, error);
+            callback(error);
+          }
+
           done();
           return;
         }
@@ -280,71 +288,86 @@ Daikin.prototype = {
    * @param {(error: Error | null, body?: string) => void} callback Called with the response body or an error.
    * @param {{ skipQueue?: boolean, skipCache?: boolean }} options Cache behaviour overrides.
    */
+  _resolveHost(callback) {
+    resolveControllerHost(this.apiIP)
+      .then(address => {
+        if (address !== this.apiIP) {
+          this.log.debug('Resolved %s to %s', this.apiIP, address);
+        }
+
+        callback(address);
+      })
+      .catch(error => {
+        this.log.warn('DNS lookup failed for %s: %s, using hostname as-is', this.apiIP, error.message);
+        callback(this.apiIP);
+      });
+  },
+
   _doSendGetRequest(path, callback, options) {
     if (this._serveFromCache && this._serveFromCache(path, callback, options)) return;
 
-    this.log.debug('_doSendGetRequest: requesting from API: path: %s', path);
+    this._resolveHost(resolvedIP => {
+      const resolvedPath = replaceHostInUrl(path, resolvedIP);
+      this.log.debug('_doSendGetRequest: requesting from API: path: %s', resolvedPath);
 
-    let request = superagent
-      .get(path)
-      .retry(this.retries)
-      .timeout({
-        response: this.response,
-        deadline: this.deadline,
-      })
-      .set('User-Agent', 'superagent')
-      .set('Host', this.apiIP);
+      let request = superagent
+        .get(resolvedPath)
+        .retry(this.retries)
+        .timeout({
+          response: this.response,
+          deadline: this.deadline,
+        })
+        .set('User-Agent', 'superagent')
+        .set('Host', resolvedIP);
 
-    if (this.uuid !== '') {
-      request = request.set('X-Daikin-uuid', this.uuid);
-    }
-
-    // Choose agent based on URL protocol and OpenSSL version to avoid .disableTLSCerts issues
-    let urlProtocol = 'https:';
-    try {
-      urlProtocol = new URL(path).protocol;
-    } catch {
-      urlProtocol = 'https:';
-    }
-
-    if (urlProtocol === 'https:') {
-      if (isOpenSSL3()) {
-        request = request.agent(getLegacyAgent());
-      } else if (typeof request.disableTLSCerts === 'function') {
-        request = request.disableTLSCerts();
-      } else {
-        request = request.agent(getDefaultAgent());
-      }
-    } else {
-      // plain http
-      request = request.agent(getDefaultHttpAgent());
-    }
-
-    request.end((error, response) => {
-      if (error) {
-        if (error.timeout) {/* timed out */}
-        else if (error.code === 'ECONNRESET') {
-          this.log.debug('_doSendGetRequest: eConnreset filtered');
-        } else {
-          this.log.error('_doSendGetRequest: ERROR: API request to %s returned error %s', path, error);
-        }
-
-        return callback && callback(error);
+      if (this.uuid !== '') {
+        request = request.set('X-Daikin-uuid', this.uuid);
       }
 
-      // Prefer text when available (keeps compatibility with parseResponse callers)
-      const body = response && (response.text ?? (typeof response.body === 'string' ? response.body : JSON.stringify(response.body)));
+      let urlProtocol = 'https:';
       try {
-        if (this.cache && typeof this.cache.set === 'function') {
-          this.log.debug('_doSendGetRequest: set cache: path: %s', path);
-          this.cache.set(path, body);
-        }
-      } catch (error) {
-        this.log.debug('_doSendGetRequest: cache set failed: %s', error.message || error);
+        urlProtocol = new URL(resolvedPath).protocol;
+      } catch {
+        urlProtocol = 'https:';
       }
 
-      this.log.debug('_doSendGetRequest: response from API: %s', body);
-      return callback && callback(null, body);
+      if (urlProtocol === 'https:') {
+        if (isOpenSSL3()) {
+          request = request.agent(getLegacyAgent());
+        } else if (typeof request.disableTLSCerts === 'function') {
+          request = request.disableTLSCerts();
+        } else {
+          request = request.agent(getDefaultAgent());
+        }
+      } else {
+        request = request.agent(getDefaultHttpAgent());
+      }
+
+      request.end((error, response) => {
+        if (error) {
+          if (error.timeout) {/* timed out */}
+          else if (error.code === 'ECONNRESET') {
+            this.log.debug('_doSendGetRequest: eConnreset filtered');
+          } else {
+            this.log.error('_doSendGetRequest: ERROR: API request to %s returned error %s', resolvedPath, error);
+          }
+
+          return callback && callback(error);
+        }
+
+        const body = response && (response.text ?? (typeof response.body === 'string' ? response.body : JSON.stringify(response.body)));
+        try {
+          if (this.cache && typeof this.cache.set === 'function') {
+            this.log.debug('_doSendGetRequest: set cache: path: %s', path);
+            this.cache.set(path, body);
+          }
+        } catch (error) {
+          this.log.debug('_doSendGetRequest: cache set failed: %s', error.message || error);
+        }
+
+        this.log.debug('_doSendGetRequest: response from API: %s', body);
+        return callback && callback(null, body);
+      });
     });
   },
 

--- a/test/config.json
+++ b/test/config.json
@@ -1,0 +1,23 @@
+{
+  "bridge": {
+    "name": "Homebridge Dev",
+    "username": "CC:22:3E:E3:CE:31",
+    "port": 51827,
+    "pin": "031-45-155"
+  },
+  "description": "Local development config for homebridge-daikin-tempsensor-nocloud",
+  "accessories": [
+    {
+      "accessory": "Daikin-Temperature",
+      "name": "Dev Indoor Sensor",
+      "apiroute": "http://127.0.0.1:18765",
+      "outsidemode": false,
+      "temperatureOffset": 0,
+      "system": "Default",
+      "response": 2000,
+      "deadline": 60000,
+      "retries": 2
+    }
+  ],
+  "platforms": []
+}

--- a/test/helpers/mock-homebridge.js
+++ b/test/helpers/mock-homebridge.js
@@ -19,23 +19,35 @@ function createMockLog() {
 function createDaikin(config = {}) {
   let Accessory;
 
+  class MockService {
+    constructor(name) {
+      this.name = name;
+    }
+
+    getCharacteristic() {
+      return {
+        setProps() {
+          return this;
+        },
+        on() {
+          return this;
+        },
+        setCharacteristic() {
+          return this;
+        },
+      };
+    }
+
+    setCharacteristic() {
+      return this;
+    }
+  }
+
   const homebridge = {
     hap: {
-      Service: class MockService {
-        constructor(name) {
-          this.name = name;
-        }
-
-        getCharacteristic() {
-          return {
-            setProps() {
-              return this;
-            },
-            on() {
-              return this;
-            },
-          };
-        }
+      Service: {
+        TemperatureSensor: MockService,
+        AccessoryInformation: MockService,
       },
       Characteristic: {
         TemperatureDisplayUnits: {CELSIUS: 0},

--- a/test/host-resolve.test.js
+++ b/test/host-resolve.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  isIpAddress,
+  resolveControllerHost,
+  replaceHostInUrl,
+  clearDnsCache,
+} = require('../src/host-resolve.js');
+
+test('isIpAddress detects IPv4 literals', () => {
+  assert.equal(isIpAddress('192.168.1.10'), true);
+  assert.equal(isIpAddress('daikin.local'), false);
+});
+
+test('resolveControllerHost returns IP literals unchanged', async () => {
+  clearDnsCache();
+  const address = await resolveControllerHost('192.168.71.136');
+  assert.equal(address, '192.168.71.136');
+});
+
+test('replaceHostInUrl swaps hostname and preserves port and path', () => {
+  const url = replaceHostInUrl('http://daikin.local:8080/aircon/get_sensor_info', '192.168.1.20');
+  assert.equal(url, 'http://192.168.1.20:8080/aircon/get_sensor_info');
+});


### PR DESCRIPTION
Aligns Node.js support with [homebridge](https://www.npmjs.com/package/homebridge) (Option C from #258).

## Changes
- **`package.json`**: `engines.node` → `^22 || ^24` (drops Node 20)
- **`README.md`**: compact static node badge (`22 | 24`); TLS note updated to Node.js 22+
- **CI**: test matrix `22.x` + `24.x`; run Node.js CI on PRs to `DEV` as well as `master`

Also brings `DEV` up to date with `master` (v1.4.7–1.4.8 feature commits included in this branch).

Closes #258