### PR TITLE
Sync DEV with master: Node engines + eslint/json bump

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, DEV ]
 
 permissions:
   contents: read
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
 
-![node](https://img.shields.io/node/v/homebridge-daikin-tempsensor-nocloud)
+[![node](https://img.shields.io/badge/node-22%20%7C%2024-brightgreen)](https://github.com/cbrandlehner/homebridge-daikin-tempsensor-nocloud/blob/master/package.json)
 [![npm](https://img.shields.io/npm/dt/homebridge-daikin-tempsensor-nocloud.svg)](https://www.npmjs.com/package/homebridge-daikin-tempsensor-nocloud)
 [![npm](https://img.shields.io/npm/l/homebridge-daikin-tempsensor-nocloud.svg)](https://github.com/cbrandlehner/homebridge-daikin-tempsensor-nocloud/blob/master/LICENSE)
 [![npm version](https://badge.fury.io/js/homebridge-daikin-tempsensor-nocloud.svg)](https://badge.fury.io/js/homebridge-daikin-tempsensor-nocloud)
@@ -71,7 +71,7 @@ ret=PARAM NG,msg=404 Not Found
 
 Some models require requests via `https` containing a registered client token.
 
-**TLS / OpenSSL 3:** No configuration is required. On Node.js 18+ (linked against OpenSSL 3.x), the plugin automatically selects a legacy TLS agent for HTTPS connections to Daikin controllers (legacy renegotiation support). At startup, Homebridge logs a line such as `TLS: HTTPS apiroute — using legacy TLS agent` when this applies. There is no `OpenSSL3` setting in the plugin config.
+**TLS / OpenSSL 3:** No configuration is required. On Node.js 22+ (linked against OpenSSL 3.x), the plugin automatically selects a legacy TLS agent for HTTPS connections to Daikin controllers (legacy renegotiation support). At startup, Homebridge logs a line such as `TLS: HTTPS apiroute — using legacy TLS agent` when this applies. There is no `OpenSSL3` setting in the plugin config.
 
 It is necessary to register a client token with each device.
 The same token may be registered with multiple devices.

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,14 +115,14 @@
       }
     },
     "node_modules/@eslint/json": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-2.0.0.tgz",
-      "integrity": "sha512-P32ZJMIopNWQd1SFhd0tgjfA/hgzUuVSqHmMi2273QaLWHWimXq6V+qL4DNKnjGzO/aNECtYW+rEJ/pWB6uP+w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-2.0.1.tgz",
+      "integrity": "sha512-Thz2j92ceUF3Bq/0TuWb3MWn3Z+Cwc8k5ptF0fakl2D4Mp8mSx07Xr1aQM4R5NoihzarWUdxfOmQ8DesGy4jOg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanwhocodes/momoa": "^3.3.10",
         "natural-compare": "^1.4.0"
       },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "engines": {
     "homebridge": "^1.10.0 || ^2.0.0-beta.0",
-    "node": "^20.19.0 || ^22.12.0 || ^24.0.0"
+    "node": "^22 || ^24"
   },
   "author": "Christian Brandlehner",
   "contributors": [


### PR DESCRIPTION
Merges DEV into master.

## Included changes
- **#263** — Align `engines.node` to `^22 || ^24` (matches Homebridge); fix README node badge; CI on Node 22 + 24
- **#262** — Bump `@eslint/json` 2.0.0 → 2.0.1

Closes #258 (already closed on DEV merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js support requirements and compatibility information to focus on Node.js 22 and 24.
  * Expanded CI coverage to run on both `master` and `DEV` branches and test against Node.js 22.x and 24.x.
  * Refreshed the README compatibility badge and clarified TLS behavior for newer Node.js versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->